### PR TITLE
Reset button state when approval throws error

### DIFF
--- a/Workflow/App_Plugins/Workflow/Backoffice/resources/actions.resource.js
+++ b/Workflow/App_Plugins/Workflow/Backoffice/resources/actions.resource.js
@@ -22,7 +22,7 @@
                 $rootScope.$emit('workflowActioned');
                 buttonState('success', id);
             } else {
-                notificationsService.error('OH SNAP', d.message);
+                notificationsService.error('OH SNAP', d.data.ExceptionMessage);
                 buttonState('error', id);
             }
         };
@@ -49,6 +49,8 @@
                         workflowResource[functionName](item.instanceGuid, model.approvalComment)
                             .then(resp => {
                                 notify(resp, fromDash, item.nodeId);
+                            }, err => {
+                                notify(err, fromDash, item.nodeId);
                             });
                        
                         workflowOverlay.close();
@@ -77,6 +79,8 @@
                         workflowResource.initiateWorkflow(id, model.comment, publish)
                             .then(resp => {
                                 notify(resp, false, id);
+                            }, err => {
+                                notify(err, false, id);
                             });
 
                         workflowOverlay.close();


### PR DESCRIPTION
Currently when approving a Publish/Unpublish operation that fails with an exception, the button stays in a "spinning"/busy state, and the user has to refresh to re-submit.  This update ensures the button state is reset, and updates the notification with the exception message.

### Old
![button-state-issue](https://user-images.githubusercontent.com/1396376/51508597-352cf100-1db3-11e9-8e2c-3ee7f2b4fce6.gif)

### New
![button-state-updated](https://user-images.githubusercontent.com/1396376/51508604-38c07800-1db3-11e9-93b6-b76b8b84146d.gif)