### PR TITLE
Add handling for `AllowPreview` in drawer buttons

### DIFF
--- a/Workflow/App_Plugins/Workflow/Backoffice/views/partials/workflowEditorFooterContentRight.html
+++ b/Workflow/App_Plugins/Workflow/Backoffice/views/partials/workflowEditorFooterContentRight.html
@@ -14,7 +14,7 @@
                 label-key="buttons_returnToList">
     </umb-button>
 
-    <umb-button ng-if="!page.isNew" 
+    <umb-button ng-if="!page.isNew && content.allowPreview" 
                 type="button"
                 button-style="info" 
                 action="(vm.active ? vm.preview(content) : preview(content))"
@@ -29,7 +29,7 @@
                 label="Save">
     </umb-button>
 
-    <umb-button-group ng-if="defaultButton && vm.excludeNode || page.trashed"
+    <umb-button-group ng-if="defaultButton && vm.excludeNode || content.trashed"
                       default-button="defaultButton"
                       sub-buttons="subButtons"
                       state="page.buttonGroupState"


### PR DESCRIPTION
Ensure the Preview button only shows when `AllowPreview` is true on the `ContentItemDisplay`.  It's true by default, but can be disabled using an event:

```
private void EditorModelEventManager_SendingContentModel(
            System.Web.Http.Filters.HttpActionExecutedContext sender,
            EditorModelEventArgs<Umbraco.Web.Models.ContentEditing.ContentItemDisplay> e)
{
        e.Model.AllowPreview = false;
}
```

This matches the behavior in the [Umbraco source](https://github.com/umbraco/Umbraco-CMS/blob/dd6e764588d22ef2b7bce01fd504ece89834f181/src/Umbraco.Web.UI.Client/src/views/components/content/edit.html#L74)

Also updated `trashed` check to use correct variable