### PR TITLE
Always Save before requesting a Publish (#101)

### DIFF
--- a/Workflow/App_Plugins/Workflow/Lang/en-US.xml
+++ b/Workflow/App_Plugins/Workflow/Lang/en-US.xml
@@ -12,7 +12,7 @@
         <key alias="cancelButtonLong">Cancel workflow</key>
         <key alias="rejectButton">Reject changes</key>
         <key alias="saveButton">Save</key>
-        <key alias="publishButton">Request publish</key>
+        <key alias="publishButton">Save and Request publish</key>
         <key alias="resubmitButton">Resubmit changes</key>
         <key alias="unpublishButton">Request unpublish</key>
         <key alias="detailButton">Workflow detail</key>


### PR DESCRIPTION
This PR changes the Request publish' button to 'Save and Request publish' as a possible solution for #101 .  The new button performs a 'Save' before displaying the existing 'Request publish' dialog.

See #101 for more context.

**Example:**
![save-and-request](https://user-images.githubusercontent.com/1396376/52608674-e4e80280-2e37-11e9-9a4b-2ff04b2c7e47.gif)
