### PR TITLE
Update check for successful Save

### DIFF
--- a/Workflow/App_Plugins/Workflow/Backoffice/controllers/workflow.drawerbuttons.controller.js
+++ b/Workflow/App_Plugins/Workflow/Backoffice/controllers/workflow.drawerbuttons.controller.js
@@ -83,7 +83,7 @@
                         // There's no way to know if the Save succeeded from here, as Umbraco returns 200 when
                         // the Saving event is canceled, and the promise only rejects for 500 errors.  For now,
                         // we'll determine success by looking for any "Success" notifications in the response.
-                        var saveSucceeded = data.notifications.some(function (notification) { return notification.type === 3 });
+                        var saveSucceeded = d.notifications.some(function (notification) { return notification.type === 3 });
 
                         if (saveSucceeded) {
                             that.workflowOverlay = workflowActionsService.initiate(editorState.current.name, editorState.current.id, true);

--- a/Workflow/App_Plugins/Workflow/Backoffice/controllers/workflow.drawerbuttons.controller.js
+++ b/Workflow/App_Plugins/Workflow/Backoffice/controllers/workflow.drawerbuttons.controller.js
@@ -76,16 +76,14 @@
                 cssClass: 'success',
                 handler: () => {
                     var that = this;
-                    var contentLastUpdateDate = $scope.content.updateDate;
 
                     // Perform a Save first, to ensure we catch scenario where the user hasn't been presented
                     // with a Save button due to issues with Umbraco's dirty-checking
                     $scope.save().then(function(d) {
                         // There's no way to know if the Save succeeded from here, as Umbraco returns 200 when
                         // the Saving event is canceled, and the promise only rejects for 500 errors.  For now,
-                        // we'll determine success by comparing the updateDate of the current form against the 
-                        // one returned from the server's new model.
-                        var saveSucceeded = d.updateDate !== contentLastUpdateDate;
+                        // we'll determine success by looking for any "Success" notifications in the response.
+                        var saveSucceeded = data.notifications.some(function (notification) { return notification.type === 3 });
 
                         if (saveSucceeded) {
                             that.workflowOverlay = workflowActionsService.initiate(editorState.current.name, editorState.current.id, true);


### PR DESCRIPTION
One last update for now ;)

This changes the way Plumber determines whether the 'Save' before a 'Save and Request publish' was successful or not.  Previously we would compare the local vs server `UpdateDate`.  During testing on an older Umbraco install (7.9.2), I noticed that a new `UpdateDate` is only returned when the model is dirty, causing Plumber to think the Save failed.  This does not appear to be the case on the latest Umbraco version.

To allow this check to work on older versions, I updated Plumber to consider the Save successful as long as any "Success" notifications exist on the model (e.g. the "Content saved" notification added by Umbraco)