### PR TITLE
Fix error on submit, when comment length above 255

### DIFF
--- a/Workflow/App_Plugins/Workflow/Backoffice/views/dialogs/workflow.submit.dialog.html
+++ b/Workflow/App_Plugins/Workflow/Backoffice/views/dialogs/workflow.submit.dialog.html
@@ -3,7 +3,7 @@
         <umb-pane ng-show="!model.isDirty">
             <p ng-show="model.isPublish">Please add a comment describing the changes.</p>
             <p ng-show="!model.isPublish">Please add a comment.</p>
-            <textarea ng-model="model.comment" no-dirty-check umb-auto-focus></textarea>
+            <textarea ng-model="model.comment" maxlength="255" no-dirty-check umb-auto-focus></textarea>
         </umb-pane>
         <umb-pane ng-show="model.isDirty">
             <div class="alert alert-warning">


### PR DESCRIPTION
Hello,

I have found a bug during sending a request to publish. 
If comment has more than 255 characters an error will occur.
The reason is no character  limit on textarea, but the max length of string in DB, both of the columns (where comments are saved) have type nvarchar(255). I mean followed columns:

- [dbo].[WorkflowInstance] .[AuthorComment]
- [dbo].[WorkflowTaskInstance].[Comment]