### PR TITLE
Switch to international date format in notifications?

### DIFF
--- a/Workflow/Extensions/TaskInstanceExtensions.cs
+++ b/Workflow/Extensions/TaskInstanceExtensions.cs
@@ -78,7 +78,7 @@ namespace Workflow.Extensions
  
                     if (taskInstance.CompletedDate != null)
                     {
-                        result += $"<br/><br/>{taskInstance.StatusName} by {taskInstance.ActionedByUser.Name} on {taskInstance.CompletedDate.Value:dd/MM/yy} at {taskInstance.CompletedDate.Value:h:mmtt}";
+                        result += $"<br/><br/>{taskInstance.StatusName} by {taskInstance.ActionedByUser.Name} on {taskInstance.CompletedDate.Value:yyyy-MM-dd} at {taskInstance.CompletedDate.Value:h:mmtt}";
                     }
 
                     if (taskInstance.Comment.HasValue())

--- a/Workflow/Extensions/TaskInstanceExtensions.cs
+++ b/Workflow/Extensions/TaskInstanceExtensions.cs
@@ -78,7 +78,7 @@ namespace Workflow.Extensions
  
                     if (taskInstance.CompletedDate != null)
                     {
-                        result += $"<br/><br/>{taskInstance.StatusName} by {taskInstance.ActionedByUser.Name} on {taskInstance.CompletedDate.Value:yyyy-MM-dd} at {taskInstance.CompletedDate.Value:h:mmtt}";
+                        result += $"<br/><br/>{taskInstance.StatusName} by {taskInstance.ActionedByUser.Name} on {taskInstance.CompletedDate.Value:d MMM yyyy} at {taskInstance.CompletedDate.Value:h:mmtt}";
                     }
 
                     if (taskInstance.Comment.HasValue())

--- a/Workflow/Extensions/WorkflowInstanceExtensions.cs
+++ b/Workflow/Extensions/WorkflowInstanceExtensions.cs
@@ -94,7 +94,7 @@ namespace Workflow.Extensions
         /// <returns>HTML tr inner html definition</returns>
         public static string BuildProcessSummary(this WorkflowInstancePoco instance)
         {
-            string result = $"<b>Workflow history</b><br/><br/>{instance.WorkflowType.Description(instance.ScheduledDate)} requested by {instance.AuthorUser.Name} on {instance.CreatedDate:dd/MM/yy}<br/>";
+            string result = $"<b>Workflow history</b><br/><br/>{instance.WorkflowType.Description(instance.ScheduledDate)} requested by {instance.AuthorUser.Name} on {instance.CreatedDate:yyyy-MM-dd}<br/>";
 
             if (instance.AuthorComment.HasValue())
             {

--- a/Workflow/Extensions/WorkflowInstanceExtensions.cs
+++ b/Workflow/Extensions/WorkflowInstanceExtensions.cs
@@ -94,7 +94,7 @@ namespace Workflow.Extensions
         /// <returns>HTML tr inner html definition</returns>
         public static string BuildProcessSummary(this WorkflowInstancePoco instance)
         {
-            string result = $"<b>Workflow history</b><br/><br/>{instance.WorkflowType.Description(instance.ScheduledDate)} requested by {instance.AuthorUser.Name} on {instance.CreatedDate:yyyy-MM-dd}<br/>";
+            string result = $"<b>Workflow history</b><br/><br/>{instance.WorkflowType.Description(instance.ScheduledDate)} requested by {instance.AuthorUser.Name} on {instance.CreatedDate:d MMM yyyy}<br/>";
 
             if (instance.AuthorComment.HasValue())
             {

--- a/Workflow/Extensions/WorkflowTypeExtensions.cs
+++ b/Workflow/Extensions/WorkflowTypeExtensions.cs
@@ -10,7 +10,7 @@ namespace Workflow.Extensions
             string typeString = type.ToString().ToTitleCase();
             if (scheduledDate.HasValue)
             {
-                return "Schedule for " + typeString + " at " + scheduledDate.Value.ToString("dd/MM/yy HH:mm");
+                return "Schedule for " + typeString + " at " + scheduledDate.Value.ToString("yyyy-MM-dd HH:mm");
             }
 
             return typeString;

--- a/Workflow/Extensions/WorkflowTypeExtensions.cs
+++ b/Workflow/Extensions/WorkflowTypeExtensions.cs
@@ -10,7 +10,7 @@ namespace Workflow.Extensions
             string typeString = type.ToString().ToTitleCase();
             if (scheduledDate.HasValue)
             {
-                return "Schedule for " + typeString + " at " + scheduledDate.Value.ToString("yyyy-MM-dd HH:mm");
+                return "Schedule for " + typeString + " at " + scheduledDate.Value.ToString("d MMM yyyy HH:mm");
             }
 
             return typeString;


### PR DESCRIPTION
How would you feel about using more friendly date formats (_10 Sept 2019_) in email notifications, to avoid confusing Plumber's friendly American users?

The only reason I suggest this is because notifications like this might be confusing at first glance:

_Publish requested by Foo on 10/09/19_ 

Let me know what you think, thanks!